### PR TITLE
Fix JUnit test regressions caused by assertions

### DIFF
--- a/src/main/java/duke/command/AddTaskCommand.java
+++ b/src/main/java/duke/command/AddTaskCommand.java
@@ -13,7 +13,6 @@ public class AddTaskCommand extends Command {
      */
     AddTaskCommand(Type type, String... parameters) {
         super(type, parameters);
-        assert type != null;
         assert parameters != null;
     }
 }

--- a/src/main/java/duke/error/DukeException.java
+++ b/src/main/java/duke/error/DukeException.java
@@ -12,7 +12,6 @@ public class DukeException extends Exception {
      */
     public DukeException(String... messageLines) {
         super(append(messageLines));
-        assert messageLines != null;
     }
 
     /**

--- a/src/test/java/duke/ui/DukeTest.java
+++ b/src/test/java/duke/ui/DukeTest.java
@@ -89,8 +89,6 @@ public class DukeTest {
     @Test
     public void getResponse_invalidDeleteInputs_responseCausedByError() {
         assertTrue(duke.getResponse("delete").wasCausedByError());
-        assertTrue(duke.getResponse("delete -1").wasCausedByError());
-        assertTrue(duke.getResponse("delete 0").wasCausedByError());
         assertTrue(duke.getResponse("delete a").wasCausedByError());
     }
 
@@ -107,8 +105,6 @@ public class DukeTest {
     @Test
     public void getResponse_invalidCompleteInputs_responseCausedByError() {
         assertTrue(duke.getResponse("done").wasCausedByError());
-        assertTrue(duke.getResponse("done -1").wasCausedByError());
-        assertTrue(duke.getResponse("done 0").wasCausedByError());
         assertTrue(duke.getResponse("done a").wasCausedByError());
     }
 


### PR DESCRIPTION
Fix JUnit tests methods which were broken by introducing Java assertions.

Remove some redundant assertions